### PR TITLE
Add Jest and sample component test

### DIFF
--- a/client/src/components/ui/__tests__/badge.test.tsx
+++ b/client/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Badge } from '../badge'
+
+describe('Badge component', () => {
+  it('renders text and applies variant classes', () => {
+    render(<Badge variant="secondary">Hello</Badge>)
+    const badge = screen.getByText('Hello')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveClass('bg-secondary')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/*.test.ts?(x)'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/client/src/$1',
+    '^@shared/(.*)$': '<rootDir>/shared/$1',
+    '^@db/(.*)$': '<rootDir>/db/$1'
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+      useESM: true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx server/index.ts",
     "build": "vite build",
     "start": "NODE_ENV=production tsx server/index.ts",
+    "test": "jest",
     "check": "tsc",
     "db:push": "drizzle-kit push --force --config=./drizzle.config.ts",
     "db:seed": "tsx db/seed.ts",
@@ -126,7 +127,12 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.9"
+    "vite": "^5.4.9",
+    "@types/jest": "^29.5.11",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "build", "dist"]
+}


### PR DESCRIPTION
## Summary
- install Jest with React Testing Library
- configure ts-jest for ESM
- create `tsconfig.jest.json`
- add a sample test for the `Badge` component

## Testing
- `npm test` *(fails: `jest` not found)*