### PR TITLE
Add Stripe environment variable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A comprehensive web-based AI LaTeX Generator that simplifies document creation t
    - `ANTHROPIC_API_KEY` (Your Anthropic API key)
    - `GROQ_API_KEY` (Your Groq API key)
    - Any other API keys needed for service integrations
+   - Stripe variables (see [Stripe Environment Variables](#stripe-environment-variables))
 
 5. **Deploy**
    - Railway will automatically deploy your application
@@ -70,6 +71,21 @@ A comprehensive web-based AI LaTeX Generator that simplifies document creation t
 2. Install dependencies: `npm install`
 3. Create a `.env` file with the required environment variables
 4. Run the application: `npm run dev`
+
+## Stripe Environment Variables
+
+The application integrates with Stripe for payment processing. Set the following
+variables in your `.env` file or deployment platform:
+
+- `STRIPE_SECRET_KEY` - server-side secret for creating customers, subscriptions
+  and handling webhooks.
+- `STRIPE_WEBHOOK_SECRET` - used to verify incoming Stripe webhooks.
+- `STRIPE_PRICE_TIER1_ID` to `STRIPE_PRICE_TIER5_ID` - price IDs for each
+  subscription tier.
+- `STRIPE_PRICE_REFILL_PACK_ID` - price ID for refill packs.
+- `VITE_STRIPE_PUBLIC_KEY` - **required for client-side checkout**. Without this
+  key, the frontend cannot initialize Stripe and payment flows will be
+  unavailable.
 
 ## License
 

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -160,6 +160,16 @@ ANTHROPIC_API_KEY=sk-...       # Optional: Your Anthropic API key
 GROQ_API_KEY=...               # Optional: Your Groq API key
 ```
 
+### Stripe Environment Variables
+
+Configure these additional variables for payment processing:
+
+- `STRIPE_SECRET_KEY` - server secret used to communicate with Stripe.
+- `STRIPE_WEBHOOK_SECRET` - verifies incoming Stripe webhook requests.
+- `STRIPE_PRICE_TIER1_ID` to `STRIPE_PRICE_TIER5_ID` - price IDs for subscription tiers.
+- `STRIPE_PRICE_REFILL_PACK_ID` - price ID for purchasing refill credits.
+- `VITE_STRIPE_PUBLIC_KEY` - **required for client-side checkout** so the frontend can load Stripe.js.
+
 ## Database Setup
 
 1. Add a PostgreSQL database in your Railway project
@@ -328,8 +338,15 @@ If you encounter errors like "Error: Docker build failed":
        - ANTHROPIC_API_KEY
        - GROQ_API_KEY
        - SESSION_SECRET (can be any secure random string)
-       - STRIPE_SECRET_KEY
-       - VITE_STRIPE_PUBLIC_KEY
+      - STRIPE_SECRET_KEY
+      - STRIPE_WEBHOOK_SECRET
+      - STRIPE_PRICE_TIER1_ID
+      - STRIPE_PRICE_TIER2_ID
+      - STRIPE_PRICE_TIER3_ID
+      - STRIPE_PRICE_TIER4_ID
+      - STRIPE_PRICE_TIER5_ID
+      - STRIPE_PRICE_REFILL_PACK_ID
+      - VITE_STRIPE_PUBLIC_KEY (required for client-side checkout)
 
 7. **Last resort: Start from a fresh project**:
    - If you continue to encounter Docker-related failures, consider creating a new Railway project


### PR DESCRIPTION
## Summary
- document Stripe-related variables in README
- mention all Stripe variables in deployment guide and highlight VITE_STRIPE_PUBLIC_KEY requirement

## Testing
- `npm run check` *(fails: Hexadecimal digit expected)*