### PR TITLE
Wrap session logs behind DEBUG_SESSIONS flag

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -131,8 +131,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     name: 'latex.sid'              // Custom name to avoid conflicts
   }));
   
-  // Add development middleware to help debug session issues
-  if (process.env.NODE_ENV !== 'production') {
+  // Optional session logging middleware for debugging
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.DEBUG_SESSIONS === 'true'
+  ) {
     app.use((req: Request, res: Response, next: NextFunction) => {
       if (req.method === 'GET' && req.path.startsWith('/api/')) {
         console.log('Session ID:', req.sessionID);


### PR DESCRIPTION
## Summary
- add optional DEBUG_SESSIONS flag so session data isn't always logged

## Testing
- `npm run check` *(fails: `Hexadecimal digit expected` in templateLoader.ts)*