### PR TITLE
Add tests for parseErrorLog

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "drizzle-kit push --force --config=./drizzle.config.ts",
     "db:seed": "tsx db/seed.ts",
     "db:generate": "drizzle-kit generate --config=./drizzle.config.ts",
-    "db:migrate": "tsx db/migrate.ts"
+    "db:migrate": "tsx db/migrate.ts",
+    "test": "node --test server/utils/__tests__/tectonic.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",

--- a/server/utils/__tests__/tectonic.test.js
+++ b/server/utils/__tests__/tectonic.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const requireTs = createRequire('/root/.nvm/versions/node/v22.15.1/lib/node_modules/typescript/lib/typescript.js');
+const ts = requireTs('typescript');
+
+function loadParseErrorLog() {
+  const src = fs.readFileSync(path.resolve('server/utils/tectonic.ts'), 'utf8');
+  const match = src.match(/function parseErrorLog[\s\S]*?return errors;\n}/);
+  if (!match) throw new Error('parseErrorLog not found');
+  const transpiled = ts.transpileModule(match[0] + '\nexport { parseErrorLog };', {
+    compilerOptions: { module: 'ES2020', target: 'ES2020' }
+  }).outputText;
+  const moduleUrl = 'data:text/javascript;base64,' + Buffer.from(transpiled).toString('base64');
+  return import(moduleUrl).then(mod => mod.parseErrorLog);
+}
+
+const parseErrorLogPromise = loadParseErrorLog();
+
+test('parses single error with message on next line', async () => {
+  const parseErrorLog = await parseErrorLogPromise;
+  const log = 'l.5 \\usepackage{foo}\nUndefined control sequence';
+  assert.deepStrictEqual(parseErrorLog(log), [
+    { line: 5, message: 'l.5 \\usepackage{foo} Undefined control sequence' }
+  ]);
+});
+
+test('parses multiple errors', async () => {
+  const parseErrorLog = await parseErrorLogPromise;
+  const log =
+    'l.5 \\usepackage{foo}\nUndefined control sequence\n' +
+    'Some text\n' +
+    'l.8 \\begin{equation}\nMissing $ inserted';
+  assert.deepStrictEqual(parseErrorLog(log), [
+    { line: 5, message: 'l.5 \\usepackage{foo} Undefined control sequence' },
+    { line: 8, message: 'l.8 \\begin{equation} Missing $ inserted' }
+  ]);
+});
+
+test('returns message line when next line not recognized', async () => {
+  const parseErrorLog = await parseErrorLogPromise;
+  const log = 'l.10 some code here\nnot an error';
+  assert.deepStrictEqual(parseErrorLog(log), [
+    { line: 10, message: 'l.10 some code here' }
+  ]);
+});

--- a/server/utils/tectonic.ts
+++ b/server/utils/tectonic.ts
@@ -280,7 +280,7 @@ function runTectonic(inputFile: string, outputDir: string): Promise<{
 /**
  * Parse Tectonic error log to extract line numbers and error messages
  */
-function parseErrorLog(errorLog: string): { line: number; message: string }[] {
+export function parseErrorLog(errorLog: string): { line: number; message: string }[] {
   const errors: { line: number; message: string }[] = [];
   
   // Common LaTeX error patterns


### PR DESCRIPTION
## Summary
- expose `parseErrorLog` from `tectonic.ts`
- add unit tests for `parseErrorLog`
- add npm `test` script

## Testing
- `npm run test`
