### PR TITLE
Add Inter font and modularize hero

### DIFF
--- a/client/src/components/hero/FeatureCards.tsx
+++ b/client/src/components/hero/FeatureCards.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Scale } from "lucide-react";
+
+const FeatureCards: React.FC = () => (
+  <div className="features-container flex justify-center flex-wrap gap-8 mt-12 w-full">
+    <div className="feature-card bg-white/90 backdrop-blur-lg rounded-2xl p-8 w-full max-w-[350px] transition-all border border-blue-500/20 shadow-md hover:-translate-y-2 hover:border-blue-500/60 hover:shadow-xl">
+      <div className="feature-icon bg-gradient-to-br from-blue-500 to-indigo-500 w-14 h-14 rounded-xl flex items-center justify-center mb-6">
+        <Scale className="w-6 h-6 text-white" />
+      </div>
+      <h3 className="text-xl font-bold mb-4 text-white">Equation Processing</h3>
+      <p className="text-white/80 leading-relaxed">
+        Complex mathematical expressions converted to perfect LaTeX syntax with precise formatting
+      </p>
+    </div>
+    <div className="feature-card bg-white/90 backdrop-blur-lg rounded-2xl p-8 w-full max-w-[350px] transition-all border border-blue-500/20 shadow-md hover:-translate-y-2 hover:border-blue-500/60 hover:shadow-xl">
+      <div className="feature-icon bg-gradient-to-br from-blue-500 to-indigo-500 w-14 h-14 rounded-xl flex items-center justify-center mb-6">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6 text-white">
+          <path d="M12 20h9"></path>
+          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
+        </svg>
+      </div>
+      <h3 className="text-xl font-bold mb-4 text-white">Adaptive Intelligence</h3>
+      <p className="text-white/80 leading-relaxed">
+        Our AI adapts to your research style and preferences to deliver personalized LaTeX documents
+      </p>
+    </div>
+    <div className="feature-card bg-white/90 backdrop-blur-lg rounded-2xl p-8 w-full max-w-[350px] transition-all border border-blue-500/20 shadow-md hover:-translate-y-2 hover:border-blue-500/60 hover:shadow-xl">
+      <div className="feature-icon bg-gradient-to-br from-blue-500 to-indigo-500 w-14 h-14 rounded-xl flex items-center justify-center mb-6">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6 text-white">
+          <circle cx="12" cy="12" r="10"></circle>
+          <line x1="2" y1="12" x2="22" y2="12"></line>
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+        </svg>
+      </div>
+      <h3 className="text-xl font-bold mb-4 text-white">Instant Compilation</h3>
+      <p className="text-white/80 leading-relaxed">
+        View and download your compiled documents immediately with live preview and PDF export
+      </p>
+    </div>
+  </div>
+);
+
+export default FeatureCards;

--- a/client/src/components/hero/HeroTitle.tsx
+++ b/client/src/components/hero/HeroTitle.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const HeroTitle: React.FC = () => (
+  <h1 className="hero-title text-5xl md:text-6xl font-extrabold mb-4 bg-gradient-to-r from-blue-500 via-blue-500 to-indigo-600 bg-clip-text text-transparent drop-shadow">
+    AI LaTeX Generator
+  </h1>
+);
+
+export default HeroTitle;

--- a/client/src/components/hero/HyperIntro.css
+++ b/client/src/components/hero/HyperIntro.css
@@ -106,18 +106,6 @@
   max-width: 800px;
 }
 
-.hero-title {
-  font-size: 4rem;
-  font-weight: 900;
-  margin-bottom: 1rem;
-  background: linear-gradient(90deg, #3b82f6, #3b82f6, #4524eb);
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  letter-spacing: -0.03em;
-  text-shadow: 0 0 5px rgba(59, 130, 246, 0.5);
-  position: relative;
-}
 
 .cursor {
   color: #3b82f6;
@@ -616,61 +604,7 @@
 }
 
 /* Feature cards */
-.features-container {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 2rem;
-  margin-top: 3rem;
-  width: 100%;
-}
 
-.feature-card {
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(10px);
-  border-radius: 16px;
-  padding: 2rem;
-  width: 100%;
-  max-width: 350px;
-  transition: all 0.3s ease;
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  box-shadow: 0 4px 15px rgba(59, 130, 246, 0.1);
-}
-
-.feature-card:hover {
-  transform: translateY(-10px);
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.2);
-}
-
-.feature-icon {
-  background: linear-gradient(45deg, #3b82f6, #6366f1);
-  width: 60px;
-  height: 60px;
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 1.5rem;
-}
-
-.feature-icon svg {
-  width: 30px;
-  height: 30px;
-  color: white;
-}
-
-.feature-card h3 {
-  font-size: 1.5rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
-  color: white;
-}
-
-.feature-card p {
-  color: rgba(255, 255, 255, 0.8);
-  line-height: 1.6;
-}
 
 /* Scroll indicator */
 .scroll-indicator {

--- a/client/src/components/hero/HyperIntro.tsx
+++ b/client/src/components/hero/HyperIntro.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import { gsap } from "gsap";
 import "./HyperIntro.css";
-import { Scale } from "lucide-react";
+import HeroTitle from "./HeroTitle";
+import PromptAnimator from "./PromptAnimator";
+import FeatureCards from "./FeatureCards";
 
 // Modern intro component with professional animation effects
 
@@ -839,87 +841,8 @@ Method B & Better for categorical variables \\\\
             <div className="tv-screen">
               <div className="scanlines"></div>
               <div className="tv-content">
-                <h1 className="hero-title">AI LaTeX Generator</h1>
-                <div className="prompt-container">
-                  <span className="prompt-text"></span>
-                  <span className="prompt-cursor">|</span>
-                </div>
-                
-                {/* CTA button - repositioned between prompt-text and latex-reveal */}
-                <div className="cta-button-container">
-                  <button
-                    className="cta-button"
-                    onClick={handleGetStartedClick}
-                    aria-label="Get started with AI LaTeX Generator"
-                  >
-                    Get Started
-                  </button>
-                </div>
-                
-                <div className="latex-reveal">
-                  <div className="latex-code" id="latex-code-container">
-                    <div id="download-pdf-button" className="download-pdf-button">
-                      <button
-                        id="pdf-download-btn"
-                        className="pdf-download-button" 
-                        onClick={() => {
-                          // Get the current LaTeX code from the container
-                          const latexCodeContainer = document.getElementById('latex-code-container');
-                          let latexCode = '';
-                          
-                          if (latexCodeContainer) {
-                            const preElement = latexCodeContainer.querySelector('pre');
-                            if (preElement) {
-                              latexCode = preElement.textContent || '';
-                            }
-                          }
-                          
-                          // Download the appropriate PDF file based on current selection
-                          const link = document.createElement('a');
-                          
-                          // Get the current template type from the display
-                          const currentPromptText = document.querySelector('.prompt-text')?.textContent || '';
-                          
-                          // Select the appropriate PDF based on the current prompt
-                          let pdfFile = '';
-                          if (currentPromptText.includes('quantum computing')) {
-                            pdfFile = '/quantum_paper.pdf';
-                          } else if (currentPromptText.includes('slideshow')) {
-                            pdfFile = '/essay_slideshow.pdf';
-                          } else if (currentPromptText.includes('mathematical report')) {
-                            pdfFile = '/math_report.pdf';
-                          } else if (currentPromptText.includes('research notes')) {
-                            pdfFile = '/research_notes.pdf';
-                          } else if (currentPromptText.includes('scientific poster')) {
-                            pdfFile = '/scientific_poster.pdf';
-                          } else {
-                            // Default to math report if no match
-                            pdfFile = '/math_report.pdf';
-                          }
-                          
-                          link.href = pdfFile;
-                          link.download = pdfFile.substring(1);
-                          
-                          document.body.appendChild(link);
-                          link.click();
-                          document.body.removeChild(link);
-                        }}
-                      >
-                        <span>Download PDF</span>
-                      </button>
-                    </div>
-                    <pre>{`\\documentclass{article}
-\\usepackage{amsmath}
-\\begin{document}
-\\title{AI Generated Document}
-\\author{AI LaTeX Generator}
-\\maketitle
-\\begin{equation}
-  E = mc^2
-\\end{equation}
-\\end{document}`}</pre>
-                  </div>
-                </div>
+                <HeroTitle />
+                <PromptAnimator onGetStarted={handleGetStartedClick} />
               </div>
               <div className="tv-glitch"></div>
             </div>
@@ -927,70 +850,7 @@ Method B & Better for categorical variables \\\\
         </div>
 
         {/* Feature cards */}
-        <div className="features-container">
-          <div className="feature-card">
-            <div className="feature-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
-              </svg>
-            </div>
-            <h3>Equation Processing</h3>
-            <p>
-              Complex mathematical expressions converted to perfect LaTeX syntax
-              with precise formatting
-            </p>
-          </div>
-
-          <div className="feature-card">
-            <div className="feature-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M12 20h9"></path>
-                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
-              </svg>
-            </div>
-            <h3>Adaptive Intelligence</h3>
-            <p>
-              Our AI adapts to your research style and preferences to deliver
-              personalized LaTeX documents
-            </p>
-          </div>
-
-          <div className="feature-card">
-            <div className="feature-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <circle cx="12" cy="12" r="10"></circle>
-                <line x1="2" y1="12" x2="22" y2="12"></line>
-                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
-              </svg>
-            </div>
-            <h3>Instant Compilation</h3>
-            <p>
-              View and download your compiled documents immediately with live
-              preview and PDF export
-            </p>
-          </div>
-        </div>
+        <FeatureCards />
       </div>
 
       {/* Scroll indicator */}

--- a/client/src/components/hero/PromptAnimator.tsx
+++ b/client/src/components/hero/PromptAnimator.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+interface PromptAnimatorProps {
+  onGetStarted: () => void;
+}
+
+const PromptAnimator: React.FC<PromptAnimatorProps> = ({ onGetStarted }) => (
+  <>
+    <div className="prompt-container">
+      <span className="prompt-text"></span>
+      <span className="prompt-cursor">|</span>
+    </div>
+    <div className="cta-button-container">
+      <button
+        className="cta-button"
+        onClick={onGetStarted}
+        aria-label="Get started with AI LaTeX Generator"
+      >
+        Get Started
+      </button>
+    </div>
+    <div className="latex-reveal">
+      <div className="latex-code" id="latex-code-container">
+        <div id="download-pdf-button" className="download-pdf-button">
+          <button
+            id="pdf-download-btn"
+            className="pdf-download-button"
+          >
+            <span>Download PDF</span>
+          </button>
+        </div>
+        <pre>{`\\documentclass{article}
+\\usepackage{amsmath}
+\\begin{document}
+\\title{AI Generated Document}
+\\author{AI LaTeX Generator}
+\\maketitle
+\\begin{equation}
+  E = mc^2
+\\end{equation}
+\\end{document}`}</pre>
+      </div>
+    </div>
+  </>
+);
+
+export default PromptAnimator;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,5 @@
-/* Import modern UI effects */
+/* Import fonts and modern UI effects */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
 @import './lib/ui-effects.css';
 
 @tailwind base;
@@ -258,6 +259,15 @@ html.has-scroll-dragging {
 
   body {
     @apply font-sans antialiased bg-gray-50 text-foreground;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-sans;
   }
 
   /* Font for code/LaTeX */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,10 @@ export default {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      fontFamily: {
+        sans: ["InterVariable", "ui-sans-serif", "system-ui", "sans-serif"],
+        heading: ["InterVariable", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## Summary
- add Inter variable font in Tailwind config
- import Google Fonts and apply to headings and body
- split hero into `HeroTitle`, `PromptAnimator`, and `FeatureCards`
- simplify HyperIntro styles

## Testing
- `npm test` *(fails: jest not found)*