### PR TITLE
Add Jest setup and initial tests

### DIFF
--- a/client/src/components/ui/__tests__/button.test.tsx
+++ b/client/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { Button } from '../button'
+
+describe('Button component', () => {
+  it('applies default variant classes', () => {
+    render(<Button>Click me</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveClass('variable-gradient')
+  })
+})

--- a/client/src/lib/__tests__/parseNotesWithOmitTags.test.ts
+++ b/client/src/lib/__tests__/parseNotesWithOmitTags.test.ts
@@ -1,0 +1,23 @@
+import { parseNotesWithOmitTags } from '../utils'
+
+describe('parseNotesWithOmitTags', () => {
+  it('handles strict OMIT tags', () => {
+    const input = '<OMIT>secret</OMIT>'
+    const result = parseNotesWithOmitTags(input)
+    expect(result).toEqual({
+      processedNotes: 'secret',
+      containsOmitTags: true,
+      isStrictOmit: true,
+    })
+  })
+
+  it('handles embedded OMIT tags', () => {
+    const input = 'Hello <OMIT>remove</OMIT> world'
+    const result = parseNotesWithOmitTags(input)
+    expect(result).toEqual({
+      processedNotes: 'Hello [REMOVE THIS CONTENT: "remove"] world',
+      containsOmitTags: true,
+      isStrictOmit: false,
+    })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ export default {
   testEnvironment: 'jsdom',
   testMatch: ['**/*.test.ts?(x)'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/client/src/$1',
     '^@shared/(.*)$': '<rootDir>/shared/$1',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- configure Jest with a setup file for RTL
- add regression test for `Button` component
- add regression tests for `parseNotesWithOmitTags`

## Testing
- `npm test --silent` *(fails: `jest` not found)*