### PR TITLE
Simplify mobile scroll effect

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -15,8 +15,8 @@ import { useToast } from "@/hooks/use-toast";
 import { useAnonymousStatus } from "@/hooks/use-anonymous-status";
 import { Button } from "@/components/ui/button";
 
-// Flag to enable/disable the mobile auto-scroll effect
-// Set to false to disable the "boop" scroll-to-top animation
+// Feature flag for the mobile auto-scroll effect. When true, the
+// "boop" style scroll-to-top animation runs once on page load.
 const ENABLE_MOBILE_SCROLL_EFFECT = true;
 
 /**
@@ -169,132 +169,15 @@ export default function Home() {
     }
   }, []);
   
-  // "Boop" effect - scroll-to-top animation on mobile
+  // Simplified mobile scroll-to-top effect. When enabled, the page will scroll
+  // to the top once on load for mobile portrait screens.
   useEffect(() => {
     if (!ENABLE_MOBILE_SCROLL_EFFECT) return;
 
-    // Only apply on mobile devices in portrait mode
-    const isMobilePortrait = () => window.innerWidth < 768 && window.innerHeight > window.innerWidth;
-    
-    if (!isMobilePortrait()) {
-      console.log("Not mobile portrait, skipping boop effect");
-      return;
+    const isMobilePortrait = window.innerWidth < 768 && window.innerHeight > window.innerWidth;
+    if (isMobilePortrait) {
+      window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
     }
-    
-    console.log("Setting up boop to top effect for mobile");
-    
-    // Create a stylesheet for our custom animation
-    const styleSheet = document.createElement("style");
-    styleSheet.id = "boop-animation-styles";
-    styleSheet.textContent = `
-      @keyframes boopToTop {
-        0% { transform: translateY(0); }
-        15% { transform: translateY(-5px); }
-        30% { transform: translateY(0); }
-        100% { transform: translateY(0); }
-      }
-      
-      .boop-container {
-        animation: boopToTop 0.65s cubic-bezier(0.33, 1, 0.68, 1) forwards;
-      }
-    `;
-    document.head.appendChild(styleSheet);
-    
-    // Add animation class to main container
-    const mainElement = document.body;
-    if (mainElement) {
-      mainElement.classList.add('boop-container');
-    }
-    
-    // Run immediate scroll to top on page load
-    const immediateScrollToTop = () => {
-      window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: 'smooth'
-      });
-      
-      // Fallback direct scroll
-      setTimeout(() => {
-        window.scrollTo(0, 0);
-        document.body.scrollTop = 0; // For Safari
-        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE
-      }, 100);
-    };
-    
-    // Call scroll immediately
-    immediateScrollToTop();
-    
-    // Set up a continuous gentle pull to top that runs
-    // every few seconds to keep the page at the top
-    const continuousPullInterval = setInterval(() => {
-      if (window.scrollY > 20) { // Only pull if we've scrolled a bit
-        immediateScrollToTop();
-      }
-    }, 750); // Check every 750ms
-    
-    // Also scroll to top whenever the user taps on an input field
-    // to make sure content is visible even when keyboard appears
-    const inputFocusHandler = () => {
-      setTimeout(() => {
-        window.scrollTo({
-          top: 0,
-          left: 0,
-          behavior: 'smooth'
-        });
-      }, 300); // Short delay to let keyboard appear
-    };
-    
-    // Add input focus listener
-    const allInputs = document.querySelectorAll('input, textarea');
-    allInputs.forEach(input => {
-      input.addEventListener('focus', inputFocusHandler);
-    });
-    
-    // Also listen for any scroll that might happen and gently pull back to top
-    const scrollHandler = () => {
-      if (window.scrollY > 20) { // Only if we've scrolled down a bit
-        // Wait a moment to see if scroll is intentional or just bounce
-        setTimeout(() => {
-          // Now check if we're still scrolled
-          if (window.scrollY > 20) {
-            // Smoothly scroll back to top
-            window.scrollTo({
-              top: 0,
-              left: 0,
-              behavior: 'smooth'
-            });
-          }
-        }, 200);
-      }
-    };
-    
-    // Add scroll listener
-    window.addEventListener('scroll', scrollHandler, { passive: true });
-    
-    // Clean up on component unmount
-    return () => {
-      // Remove animation styles
-      const styleElement = document.getElementById('boop-animation-styles');
-      if (styleElement) {
-        styleElement.remove();
-      }
-      
-      // Remove animation class
-      if (mainElement) {
-        mainElement.classList.remove('boop-container');
-      }
-      
-      // Clear intervals
-      clearInterval(continuousPullInterval);
-      
-      // Remove listeners
-      allInputs.forEach(input => {
-        input.removeEventListener('focus', inputFocusHandler);
-      });
-      
-      window.removeEventListener('scroll', scrollHandler);
-    };
   }, []);
   
   // Check localStorage for preselected template when coming from template URL


### PR DESCRIPTION
## Summary
- gate the mobile scroll to top feature behind a flag
- remove the complex continuous scroll logic
- enable the scroll effect by default

## Testing
- `npm test` *(fails: jest not found)*
