### PR TITLE
Add Jest tests for parseErrorLog

### DIFF
--- a/server/utils/__tests__/tectonic.test.ts
+++ b/server/utils/__tests__/tectonic.test.ts
@@ -1,0 +1,48 @@
+import { parseErrorLog } from '../tectonic';
+
+describe('parseErrorLog', () => {
+  test('parses message on the next line', () => {
+    const log = [
+      'l.12 \\beign',
+      'Undefined control sequence'
+    ].join('\n');
+    const result = parseErrorLog(log);
+    expect(result).toEqual([
+      {
+        line: 12,
+        message: 'l.12 \\beign Undefined control sequence'
+      }
+    ]);
+  });
+
+  test('parses message on the same line', () => {
+    const log = 'l.34 Missing $ inserted';
+    const result = parseErrorLog(log);
+    expect(result).toEqual([
+      {
+        line: 34,
+        message: 'l.34 Missing $ inserted'
+      }
+    ]);
+  });
+
+  test('parses multiple errors', () => {
+    const log = [
+      'l.3 \\foo',
+      'Undefined control sequence',
+      'some other info',
+      'l.20 Missing $ inserted'
+    ].join('\n');
+    const result = parseErrorLog(log);
+    expect(result).toEqual([
+      {
+        line: 3,
+        message: 'l.3 \\foo Undefined control sequence'
+      },
+      {
+        line: 20,
+        message: 'l.20 Missing $ inserted'
+      }
+    ]);
+  });
+});

--- a/server/utils/tectonic.ts
+++ b/server/utils/tectonic.ts
@@ -280,7 +280,7 @@ function runTectonic(inputFile: string, outputDir: string): Promise<{
 /**
  * Parse Tectonic error log to extract line numbers and error messages
  */
-function parseErrorLog(errorLog: string): { line: number; message: string }[] {
+export function parseErrorLog(errorLog: string): { line: number; message: string }[] {
   const errors: { line: number; message: string }[] = [];
   
   // Common LaTeX error patterns


### PR DESCRIPTION
## Summary
- export `parseErrorLog` from `tectonic.ts`
- add unit tests for `parseErrorLog`

## Testing
- `npm test` *(fails: jest not found)*