### PR TITLE
Add Undetectable AI test page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import DocumentHistory from "@/pages/document-history";
 import VerifyEmail from "@/pages/verify-email";
 import Success from "@/pages/success";
 import UIPlayground from "@/pages/ui-playground";
+import UndetectableTest from "@/pages/undetectable-test";
 import TemplateRedirect from "@/pages/template-redirect";
 import PrivacyPolicy from "@/pages/privacy-policy";
 import IntroPage from "@/pages/intro-page";
@@ -75,6 +76,7 @@ function Router() {
       <Route path="/history" component={DocumentHistory} />
       <Route path="/verify-email" component={VerifyEmail} />
       <Route path="/ui-playground" component={UIPlayground} />
+      <Route path="/undetectable-test" component={UndetectableTest} />
       <Route path="/template/:type" component={TemplateRedirect} />
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route component={NotFound} />

--- a/client/src/pages/undetectable-test.tsx
+++ b/client/src/pages/undetectable-test.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import SiteLayout from "@/components/layout/site-layout";
+import { Button } from "@/components/ui/button";
+
+export default function UndetectableTest() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleRewrite = async () => {
+    if (!input.trim()) return;
+    setLoading(true);
+    setOutput("");
+    try {
+      const res = await fetch("/api/undetectable/rewrite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: input })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setOutput(data.text);
+      } else {
+        setOutput(data.message || "Error");
+      }
+    } catch {
+      setOutput("Error rewriting text");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SiteLayout seoTitle="Undetectable AI Test">
+      <div className="h-full flex flex-col md:flex-row bg-gradient-soft">
+        <div className="w-full md:w-1/2 h-full relative">
+          <div className="absolute inset-4 glass rounded-lg shadow-lg overflow-hidden depth-3d p-4 flex flex-col">
+            <h2 className="text-lg font-semibold mb-2">Input</h2>
+            <textarea
+              className="flex-1 w-full rounded-md border border-gray-300 p-2 glass-card resize-none text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Enter text to rewrite..."
+            />
+            <Button
+              className="mt-2 self-end"
+              onClick={handleRewrite}
+              disabled={loading || !input.trim()}
+            >
+              {loading ? "Rewriting..." : "Rewrite"}
+            </Button>
+          </div>
+        </div>
+        <div className="w-full md:w-1/2 h-full relative">
+          <div className="absolute inset-4 glass rounded-lg shadow-lg overflow-hidden depth-3d p-4 flex flex-col">
+            <h2 className="text-lg font-semibold mb-2">Output</h2>
+            <textarea
+              readOnly
+              className="flex-1 w-full rounded-md border border-gray-300 p-2 glass-card resize-none text-sm font-mono focus:outline-none"
+              value={output}
+            />
+          </div>
+        </div>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/server/services/aiProvider.ts
+++ b/server/services/aiProvider.ts
@@ -543,4 +543,35 @@ export async function modifyLatex(
   }
 }
 
+export async function rewriteHumanText(text: string) {
+  try {
+    if (!openaiClient) throw new Error('OpenAI API not configured');
+
+    const response = await openaiClient.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You rewrite text to appear naturally written by a human while preserving the original meaning.'
+        },
+        { role: 'user', content: `Rewrite this text:\n\n${text}` }
+      ],
+      temperature: 0.7,
+      max_tokens: 2000
+    });
+
+    return {
+      success: true,
+      text: response.choices[0].message.content?.trim() || ''
+    };
+  } catch (error) {
+    console.error('Error rewriting text:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to rewrite text'
+    };
+  }
+}
+
 // exports are already defined individually throughout the file

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -155,3 +155,10 @@ export const tierPrices = {
  */
 export const REFILL_PACK_CREDITS = 100;  // Each refill pack adds 100 requests
 export const REFILL_PACK_PRICE = 0.99;   // Each refill pack costs $0.99 (one-time purchase)
+
+// Schema for rewriting text using the Undetectable AI test page
+export const rewriteSchema = z.object({
+  text: z.string().min(1, "Text is required")
+});
+
+export type RewriteRequest = z.infer<typeof rewriteSchema>;


### PR DESCRIPTION
## Summary
- add rewrite schema to shared types
- add `rewriteHumanText` helper
- expose `/api/undetectable/rewrite` endpoint
- new page `undetectable-test` to try rewriting
- wire page into router

## Testing
- `npm test`