### PR TITLE
Add Groq feature suite

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import VerifyEmail from "@/pages/verify-email";
 import Success from "@/pages/success";
 import UIPlayground from "@/pages/ui-playground";
 import UndetectableTest from "@/pages/undetectable-test";
+import GroqSuite from "@/pages/groq-suite";
 import TemplateRedirect from "@/pages/template-redirect";
 import PrivacyPolicy from "@/pages/privacy-policy";
 import IntroPage from "@/pages/intro-page";
@@ -81,6 +82,7 @@ function Router() {
       <Route path="/verify-email" component={VerifyEmail} />
       <Route path="/ui-playground" component={UIPlayground} />
       <Route path="/undetectable" component={UndetectableTest} />
+      <Route path="/groq-suite" component={GroqSuite} />
       <Route path="/template/:type" component={TemplateRedirect} />
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route path="/contact" component={Contact} />

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -80,6 +80,12 @@ export const API_ROUTES = {
   undetectable: {
     rewrite: "/api/undetectable/rewrite"
   },
+  groq: {
+    summarize: "/api/groq/summarize",
+    outline: "/api/groq/outline",
+    glossary: "/api/groq/glossary",
+    flashcards: "/api/groq/flashcards"
+  },
   subscription: {
     create: "/api/subscription/create",
     manage: "/api/subscription/manage",

--- a/client/src/lib/groq-suite.ts
+++ b/client/src/lib/groq-suite.ts
@@ -1,0 +1,39 @@
+import { API_ROUTES } from "./constants";
+import { apiRequest } from "./queryClient";
+
+export interface SummaryResponse {
+  summary: string;
+}
+
+export interface OutlineResponse {
+  outline: string;
+}
+
+export interface GlossaryResponse {
+  glossary: string;
+}
+
+export interface FlashcardsResponse {
+  flashcards: string;
+}
+
+export async function generateSummary(text: string): Promise<SummaryResponse> {
+  const res = await apiRequest("POST", API_ROUTES.groq.summarize, { text });
+  return res.json();
+}
+
+export async function generateOutline(text: string): Promise<OutlineResponse> {
+  const res = await apiRequest("POST", API_ROUTES.groq.outline, { text });
+  return res.json();
+}
+
+export async function generateGlossary(text: string): Promise<GlossaryResponse> {
+  const res = await apiRequest("POST", API_ROUTES.groq.glossary, { text });
+  return res.json();
+}
+
+export async function generateFlashcards(text: string): Promise<FlashcardsResponse> {
+  const res = await apiRequest("POST", API_ROUTES.groq.flashcards, { text });
+  return res.json();
+}
+

--- a/client/src/pages/groq-suite.tsx
+++ b/client/src/pages/groq-suite.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import SiteLayout from "@/components/layout/site-layout";
+import { Button } from "@/components/ui/button";
+import { generateSummary, generateOutline, generateGlossary, generateFlashcards } from "@/lib/groq-suite";
+
+const modes = [
+  { id: "summary", label: "Summary" },
+  { id: "outline", label: "Outline" },
+  { id: "glossary", label: "Glossary" },
+  { id: "flashcards", label: "Flashcards" }
+];
+
+export default function GroqSuite() {
+  const [mode, setMode] = useState("summary");
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleRun = async () => {
+    if (!input.trim()) return;
+    setLoading(true);
+    setOutput("");
+    try {
+      if (mode === "summary") {
+        const res = await generateSummary(input);
+        setOutput(res.summary);
+      } else if (mode === "outline") {
+        const res = await generateOutline(input);
+        setOutput(res.outline);
+      } else if (mode === "glossary") {
+        const res = await generateGlossary(input);
+        setOutput(res.glossary);
+      } else {
+        const res = await generateFlashcards(input);
+        setOutput(res.flashcards);
+      }
+    } catch (err) {
+      console.error(err);
+      setOutput("Error generating output");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SiteLayout seoTitle="Groq Toolkit">
+      <div className="h-full flex flex-col md:flex-row bg-gradient-soft">
+        <div className="w-full md:w-1/2 h-full relative">
+          <div className="absolute inset-4 glass rounded-lg shadow-lg overflow-hidden depth-3d p-4 flex flex-col space-y-2">
+            <h2 className="text-lg font-semibold">Input</h2>
+            <select
+              className="border border-gray-300 rounded-md p-2"
+              value={mode}
+              onChange={(e) => setMode(e.target.value)}
+            >
+              {modes.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            <textarea
+              className="flex-1 rounded-md border border-gray-300 p-2 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+            />
+            <Button onClick={handleRun} disabled={loading || input.trim().length === 0}>
+              {loading ? "Processing..." : "Run"}
+            </Button>
+          </div>
+        </div>
+        <div className="w-full md:w-1/2 h-full relative">
+          <div className="absolute inset-4 glass rounded-lg shadow-lg overflow-hidden depth-3d p-4 flex flex-col">
+            <h2 className="text-lg font-semibold mb-2">Output</h2>
+            <textarea
+              readOnly
+              className="flex-1 rounded-md border border-gray-300 p-2 resize-none bg-gray-50"
+              value={output}
+            />
+          </div>
+        </div>
+      </div>
+    </SiteLayout>
+  );
+}
+

--- a/server/services/aiProvider.ts
+++ b/server/services/aiProvider.ts
@@ -613,4 +613,204 @@ export async function rewriteText(
   }
 }
 
+const SUMMARY_SYSTEM_PROMPT = `You are a professional academic assistant. Provide a concise summary of the user's text in 3-5 bullet points.`;
+
+export async function generateSummary(
+  text: string,
+  model: string = 'llama3-8b-8192'
+): Promise<{ success: boolean; summary?: string; error?: string }> {
+  if (!groqApiKey) {
+    return { success: false, error: 'Groq API not configured' };
+  }
+
+  const provider = providers.groq as any;
+  const systemTokens = Math.ceil(SUMMARY_SYSTEM_PROMPT.split(/\s+/).length * 1.3);
+  const textTokens = Math.ceil(text.split(/\s+/).length * 1.3);
+  const estimatedRequestTokens = systemTokens + textTokens + 400;
+
+  if (provider.totalTokensUsed + estimatedRequestTokens > provider.MAX_TOKENS) {
+    return { success: false, error: 'Groq spending limit exceeded' };
+  }
+
+  try {
+    const resp = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model,
+        messages: [
+          { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
+          { role: 'user', content: text }
+        ],
+        temperature: 0.3,
+        max_tokens: 400
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${groqApiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    const tokensUsed = resp.data.usage?.total_tokens || estimatedRequestTokens;
+    provider.totalTokensUsed += tokensUsed;
+    return { success: true, summary: resp.data.choices[0].message.content.trim() };
+  } catch (error) {
+    const errorObj = error as any;
+    if (errorObj.response?.status === 429) {
+      provider.totalTokensUsed = provider.MAX_TOKENS;
+    }
+    return { success: false, error: errorObj.message || 'Failed to summarize text' };
+  }
+}
+
+const OUTLINE_SYSTEM_PROMPT = `You create concise bullet-point outlines capturing the major topics of the user's text.`;
+
+export async function generateOutline(
+  text: string,
+  model: string = 'llama3-8b-8192'
+): Promise<{ success: boolean; outline?: string; error?: string }> {
+  if (!groqApiKey) {
+    return { success: false, error: 'Groq API not configured' };
+  }
+
+  const provider = providers.groq as any;
+  const systemTokens = Math.ceil(OUTLINE_SYSTEM_PROMPT.split(/\s+/).length * 1.3);
+  const textTokens = Math.ceil(text.split(/\s+/).length * 1.3);
+  const estimatedRequestTokens = systemTokens + textTokens + 400;
+
+  if (provider.totalTokensUsed + estimatedRequestTokens > provider.MAX_TOKENS) {
+    return { success: false, error: 'Groq spending limit exceeded' };
+  }
+
+  try {
+    const resp = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model,
+        messages: [
+          { role: 'system', content: OUTLINE_SYSTEM_PROMPT },
+          { role: 'user', content: text }
+        ],
+        temperature: 0.3,
+        max_tokens: 400
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${groqApiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    const tokensUsed = resp.data.usage?.total_tokens || estimatedRequestTokens;
+    provider.totalTokensUsed += tokensUsed;
+    return { success: true, outline: resp.data.choices[0].message.content.trim() };
+  } catch (error) {
+    const errorObj = error as any;
+    if (errorObj.response?.status === 429) {
+      provider.totalTokensUsed = provider.MAX_TOKENS;
+    }
+    return { success: false, error: errorObj.message || 'Failed to create outline' };
+  }
+}
+
+const GLOSSARY_SYSTEM_PROMPT = `Extract key terms from the user's text and provide short definitions in the form "Term: definition".`;
+
+export async function generateGlossary(
+  text: string,
+  model: string = 'llama3-8b-8192'
+): Promise<{ success: boolean; glossary?: string; error?: string }> {
+  if (!groqApiKey) {
+    return { success: false, error: 'Groq API not configured' };
+  }
+
+  const provider = providers.groq as any;
+  const systemTokens = Math.ceil(GLOSSARY_SYSTEM_PROMPT.split(/\s+/).length * 1.3);
+  const textTokens = Math.ceil(text.split(/\s+/).length * 1.3);
+  const estimatedRequestTokens = systemTokens + textTokens + 400;
+
+  if (provider.totalTokensUsed + estimatedRequestTokens > provider.MAX_TOKENS) {
+    return { success: false, error: 'Groq spending limit exceeded' };
+  }
+
+  try {
+    const resp = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model,
+        messages: [
+          { role: 'system', content: GLOSSARY_SYSTEM_PROMPT },
+          { role: 'user', content: text }
+        ],
+        temperature: 0.3,
+        max_tokens: 400
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${groqApiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    const tokensUsed = resp.data.usage?.total_tokens || estimatedRequestTokens;
+    provider.totalTokensUsed += tokensUsed;
+    return { success: true, glossary: resp.data.choices[0].message.content.trim() };
+  } catch (error) {
+    const errorObj = error as any;
+    if (errorObj.response?.status === 429) {
+      provider.totalTokensUsed = provider.MAX_TOKENS;
+    }
+    return { success: false, error: errorObj.message || 'Failed to generate glossary' };
+  }
+}
+
+const FLASHCARD_SYSTEM_PROMPT = `Create brief study flashcards from the user's text. Respond with a numbered list where each item contains a question and its answer.`;
+
+export async function generateFlashcards(
+  text: string,
+  model: string = 'llama3-8b-8192'
+): Promise<{ success: boolean; flashcards?: string; error?: string }> {
+  if (!groqApiKey) {
+    return { success: false, error: 'Groq API not configured' };
+  }
+
+  const provider = providers.groq as any;
+  const systemTokens = Math.ceil(FLASHCARD_SYSTEM_PROMPT.split(/\s+/).length * 1.3);
+  const textTokens = Math.ceil(text.split(/\s+/).length * 1.3);
+  const estimatedRequestTokens = systemTokens + textTokens + 400;
+
+  if (provider.totalTokensUsed + estimatedRequestTokens > provider.MAX_TOKENS) {
+    return { success: false, error: 'Groq spending limit exceeded' };
+  }
+
+  try {
+    const resp = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model,
+        messages: [
+          { role: 'system', content: FLASHCARD_SYSTEM_PROMPT },
+          { role: 'user', content: text }
+        ],
+        temperature: 0.3,
+        max_tokens: 400
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${groqApiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    const tokensUsed = resp.data.usage?.total_tokens || estimatedRequestTokens;
+    provider.totalTokensUsed += tokensUsed;
+    return { success: true, flashcards: resp.data.choices[0].message.content.trim() };
+  } catch (error) {
+    const errorObj = error as any;
+    if (errorObj.response?.status === 429) {
+      provider.totalTokensUsed = provider.MAX_TOKENS;
+    }
+    return { success: false, error: errorObj.message || 'Failed to create flashcards' };
+  }
+}
+
 // exports are already defined individually throughout the file


### PR DESCRIPTION
## Summary
- add Groq summarization, outline, glossary and flashcard utilities
- expose new endpoints `/api/groq/*`
- hook up a simple client page to test the features
- support client library helpers and routing

## Testing
- `npm test`
