### PR TITLE
Enforce tier limits for all users

### DIFF
--- a/server/middleware/subscription.ts
+++ b/server/middleware/subscription.ts
@@ -4,12 +4,8 @@ import { SubscriptionTier, tierLimits } from '@shared/schema';
 
 /**
  * Middleware to check if a user has exceeded their subscription limits.
- * Usage limits can be bypassed by setting `DISABLE_USAGE_LIMITS=true`.
  */
 export async function checkSubscription(req: Request, res: Response, next: NextFunction) {
-  if (process.env.DISABLE_USAGE_LIMITS === 'true') {
-    return next();
-  }
 
   // Allow anonymous users a limited number of requests
   if (!req.session.userId) {
@@ -100,13 +96,8 @@ export async function resetMonthlyUsage(): Promise<void> {
 
 /**
  * Middleware to check if requested model is available for user's tier
- * NOTE: Model tier restrictions have been temporarily disabled for testing purposes
  */
 export async function checkModelAccess(req: Request, res: Response, next: NextFunction) {
-  // TEMPORARY: Skip all model access checks
-  return next();
-  
-  /* Original implementation (currently disabled)
   const { model } = req.body.options || {};
   
   // If no specific model is requested, continue
@@ -153,5 +144,4 @@ export async function checkModelAccess(req: Request, res: Response, next: NextFu
     console.error('Model access check error:', error);
     next(); // Continue anyway to use default model
   }
-  */
 }


### PR DESCRIPTION
## Summary
- remove `DISABLE_USAGE_LIMITS` bypass in `checkSubscription`
- enable `checkModelAccess` logic
- update subscription middleware tests
- test anonymous user limit enforcement

## Testing
- `npm test`
