### PR TITLE
Add contact form API

### DIFF
--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -121,9 +121,53 @@ export async function sendVerificationEmail(
     };
   } catch (error: any) {
     console.error('Failed to send verification email:', error);
-    return { 
-      success: false, 
-      message: `Failed to send verification email: ${error.message || 'Unknown error'}` 
+    return {
+      success: false,
+      message: `Failed to send verification email: ${error.message || 'Unknown error'}`
+    };
+  }
+}
+
+export async function sendContactEmail(
+  name: string,
+  email: string,
+  subject: string,
+  message: string
+): Promise<{ success: boolean; message: string }> {
+  if (!client) {
+    return {
+      success: false,
+      message: 'Email service not available'
+    };
+  }
+
+  const contactSubject = subject ? `Contact: ${subject}` : 'Contact Form Message';
+
+  try {
+    const response = await client.sendEmail({
+      From: FROM_EMAIL,
+      To: 'support@aitexgen.com',
+      ReplyTo: email,
+      Subject: contactSubject,
+      HtmlBody: `
+        <p><strong>Name:</strong> ${name}</p>
+        <p><strong>Email:</strong> ${email}</p>
+        <p><strong>Message:</strong></p>
+        <p>${message.replace(/\n/g, '<br>')}</p>
+      `,
+      TextBody: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+      MessageStream: 'outbound'
+    });
+
+    return {
+      success: true,
+      message: `Contact email sent: ${response.MessageID}`
+    };
+  } catch (error: any) {
+    console.error('Failed to send contact email:', error);
+    return {
+      success: false,
+      message: `Failed to send contact email: ${error.message || 'Unknown error'}`
     };
   }
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -162,3 +162,13 @@ export const rewriteSchema = z.object({
 });
 
 export type RewriteRequest = z.infer<typeof rewriteSchema>;
+
+// Schema for contact form submissions
+export const contactSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Must provide a valid email'),
+  subject: z.string().optional(),
+  message: z.string().min(1, 'Message is required')
+});
+
+export type ContactForm = z.infer<typeof contactSchema>;


### PR DESCRIPTION
## Summary
- support contact form submission in shared schema
- send contact emails with Postmark
- expose `/api/contact` endpoint

## Testing
- `npm test`