### PR TITLE
Add TEST_PRO_PLAN_PRICE_ID variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ STRIPE_PRICE_TIER3_ID=price_tier3_id_here
 STRIPE_PRICE_TIER4_ID=price_tier4_id_here
 STRIPE_PRICE_TIER5_ID=price_tier5_id_here
 STRIPE_PRICE_REFILL_PACK_ID=price_refill_pack_id_here
+TEST_PRO_PLAN_PRICE_ID=test_pro_plan_price_id_here
 
 # Domain Configuration (for Production)
 DOMAIN=https://your-domain.com

--- a/test-pro-plan-checkout.js
+++ b/test-pro-plan-checkout.js
@@ -13,8 +13,8 @@ config();
 // Initialize Stripe with your secret key
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-// Pro Plan Price ID - hardcoded to the tax-inclusive one we updated in shared/stripe-config.ts
-const proPlanPriceId = 'price_1RQTn0FlLCnouIYKOMOghgIp'; // Pro Plan with tax-inclusive pricing
+// Pro Plan Price ID used for testing - should point to the tax-inclusive price
+const proPlanPriceId = process.env.TEST_PRO_PLAN_PRICE_ID;
 
 async function testProPlanCheckout() {
   console.log('=== Testing Pro Plan Checkout Session ===');


### PR DESCRIPTION
## Summary
- add `TEST_PRO_PLAN_PRICE_ID` to `.env.example`
- read the new env variable in the Pro plan checkout test script

## Testing
- `npm test` *(fails: test-pro-plan-checkout.js cannot find `dotenv`)*