### PR TITLE
Add shader background and theme toggle

### DIFF
--- a/client/src/components/background/ShaderBackground.css
+++ b/client/src/components/background/ShaderBackground.css
@@ -1,0 +1,9 @@
+.shader-bg-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: -1;
+}

--- a/client/src/components/background/ShaderBackground.tsx
+++ b/client/src/components/background/ShaderBackground.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from "react";
+import reglInit from "regl";
+import "./ShaderBackground.css";
+
+const ShaderBackground: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const regl = reglInit({ canvas });
+    let mouse = [0.5, 0.5];
+
+    const handleMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      mouse = [
+        (e.clientX - rect.left) / rect.width,
+        1 - (e.clientY - rect.top) / rect.height,
+      ];
+    };
+
+    const handleTouch = (e: TouchEvent) => {
+      if (!e.touches[0]) return;
+      const rect = canvas.getBoundingClientRect();
+      mouse = [
+        (e.touches[0].clientX - rect.left) / rect.width,
+        1 - (e.touches[0].clientY - rect.top) / rect.height,
+      ];
+    };
+
+    canvas.addEventListener("mousemove", handleMove);
+    canvas.addEventListener("touchmove", handleTouch, { passive: true });
+
+    const draw = regl({
+      frag: `
+        precision mediump float;
+        uniform vec2 mouse;
+        uniform float time;
+        varying vec2 uv;
+        void main() {
+          vec2 p = uv - mouse;
+          float d = length(p);
+          float glow = 0.015 / d;
+          float wave = sin(10.0 * d - time * 2.0);
+          vec3 color = mix(vec3(0.2,0.3,0.6), vec3(0.8,0.2,0.6), wave);
+          gl_FragColor = vec4(color * glow, 1.0);
+        }
+      `,
+      vert: `
+        precision mediump float;
+        attribute vec2 position;
+        varying vec2 uv;
+        void main() {
+          uv = position * 0.5 + 0.5;
+          gl_Position = vec4(position, 0, 1);
+        }
+      `,
+      attributes: {
+        position: [
+          [-1, -1],
+          [-1, 1],
+          [1, 1],
+          [1, -1],
+        ],
+      },
+      elements: [
+        [0, 1, 2],
+        [0, 2, 3],
+      ],
+      uniforms: {
+        mouse: () => mouse,
+        time: ({ time }: { time: number }) => time,
+      },
+    });
+
+    const frame = regl.frame(() => {
+      draw();
+    });
+
+    const handleResize = () => {
+      canvas.width = canvas.clientWidth;
+      canvas.height = canvas.clientHeight;
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      frame.cancel();
+      canvas.removeEventListener("mousemove", handleMove);
+      canvas.removeEventListener("touchmove", handleTouch);
+      window.removeEventListener("resize", handleResize);
+      regl.destroy();
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="shader-bg-canvas" />;
+};
+
+export default ShaderBackground;

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -9,6 +9,7 @@ import SubscriptionModal from "@/components/dialogs/subscription-modal";
 import { getUsageColor } from "@/lib/utils";
 import { SubscriptionTier } from "@shared/schema.ts";
 import { Loader2 } from "lucide-react";
+import ThemeToggle from "@/components/ui/theme-toggle";
 
 export default function Header() {
   const [location, navigate] = useLocation();
@@ -92,6 +93,7 @@ export default function Header() {
         </div>
         
         <div className="flex items-center space-x-4">
+          <ThemeToggle />
 
           {session.isLoading ? (
             <div className="flex items-center">

--- a/client/src/components/ui/theme-toggle.tsx
+++ b/client/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+import { gsap } from "gsap";
+
+const lightVars = {
+  "--background": "0 0% 100%",
+  "--foreground": "222.2 84% 4.9%",
+};
+
+const darkVars = {
+  "--background": "222.2 84% 4.9%",
+  "--foreground": "210 40% 98%",
+};
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+      setIsDark(true);
+    }
+  }, []);
+
+  const handleToggle = () => {
+    const root = document.documentElement;
+    const targetVars = isDark ? lightVars : darkVars;
+    gsap.to(root, {
+      duration: 0.6,
+      ease: "power2.out",
+      ...targetVars,
+      onComplete: () => {
+        root.classList.toggle("dark", !isDark);
+        Object.keys(targetVars).forEach(v => root.style.removeProperty(v));
+        const newTheme = isDark ? "light" : "dark";
+        localStorage.setItem("theme", newTheme);
+        setIsDark(!isDark);
+      },
+    });
+  };
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      onClick={handleToggle}
+      className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 transition-colors"
+    >
+      {isDark ? (
+        <Sun className="h-5 w-5 text-yellow-300" />
+      ) : (
+        <Moon className="h-5 w-5 text-gray-800" />
+      )}
+    </button>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -3,6 +3,7 @@ import { useState, useContext, useEffect } from "react";
 import { useLocation } from "wouter";
 import { UserContext, AuthRequiredContext } from "@/App";
 import SiteLayout from "@/components/layout/site-layout";
+import ShaderBackground from "@/components/background/ShaderBackground";
 import TabsWithContent from "@/components/ui/tabs-with-content";
 import LatexInput from "@/components/editor/latex-input";
 import LatexOutput from "@/components/editor/latex-output";
@@ -912,7 +913,10 @@ export default function Home() {
   
   return (
     <SiteLayout seoTitle="AI LaTeX Generator - Create Professional LaTeX Documents with AI">
-      <div className="h-full flex flex-col md:flex-row bg-gradient-soft">
+      <div className="absolute inset-0 -z-10">
+        <ShaderBackground />
+      </div>
+      <div className="relative h-full flex flex-col md:flex-row bg-gradient-soft">
         
         {/* Left Panel (Input) */}
         <div className="w-full md:w-1/2 h-full relative">

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "express-session": "^1.18.1",
     "framer-motion": "^11.18.2",
     "gsap": "^3.13.0",
+    "regl": "^2.1.0",
     "input-otp": "^1.2.4",
     "jsonwebtoken": "^9.0.2",
     "locomotive-scroll": "^4.1.4",


### PR DESCRIPTION
## Summary
- create `ShaderBackground` using `regl` for mouse-reactive visuals
- add `theme-toggle` component driven by GSAP animations
- integrate shader background on Home page
- include toggle button in header for dark/light mode
- declare regl dependency

## Testing
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv')*