### PR TITLE
Add community forum and showcase pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import FAQ from "@/pages/faq";
 import HowTo from "@/pages/how-to";
 import Contact from "@/pages/contact";
 import Community from "@/pages/community";
+import Showcase from "@/pages/showcase";
 
 // Components
 import AuthRequiredDialog from "@/components/dialogs/auth-required-dialog";
@@ -88,6 +89,7 @@ function Router() {
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route path="/contact" component={Contact} />
       <Route path="/community" component={Community} />
+      <Route path="/showcase" component={Showcase} />
       <Route path="/how-to" component={HowTo} />
       <Route path="/faq" component={FAQ} />
       <Route component={NotFound} />

--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -83,6 +83,11 @@ export default function Footer() {
               </Link>
             </li>
             <li>
+              <Link href="/showcase" className="text-blue-600 hover:text-blue-800 text-sm">
+                Showcase
+              </Link>
+            </li>
+            <li>
               <Link href="/contact" className="text-blue-600 hover:text-blue-800 text-sm">
                 Contact Us
               </Link>

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -95,5 +95,10 @@ export const API_ROUTES = {
       create: "/api/subscription/refill/create",
       success: "/api/subscription/refill/success"
     }
+  },
+  community: {
+    posts: "/api/posts",
+    post: (id: number | string) => `/api/posts/${id}`,
+    showcase: "/api/showcase"
   }
 };

--- a/client/src/pages/community.tsx
+++ b/client/src/pages/community.tsx
@@ -1,12 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import SiteLayout from "@/components/layout/site-layout";
 
-const samplePosts = [
-  { author: 'Alice', message: 'Welcome to the community forum!' },
-  { author: 'Bob', message: 'Feel free to share LaTeX tips and tricks.' }
-];
+interface Post {
+  id: number;
+  userId: number;
+  title: string;
+  content: string;
+  username: string;
+  upvotes: number;
+}
 
 export default function Community() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
   useEffect(() => {
     document.title = "Community Forum - AI LaTeX Generator";
     const metaDescription = document.querySelector('meta[name="description"]');
@@ -16,7 +24,43 @@ export default function Community() {
         'Join the AI LaTeX Generator community to ask questions and share ideas.'
       );
     }
+    fetch('/api/posts')
+      .then((res) => res.json())
+      .then((data) => setPosts(data))
+      .catch((err) => console.error('Fetch posts error', err));
   }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/api/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, content })
+      });
+      if (res.ok) {
+        const newPost = await res.json();
+        setPosts([...posts, { ...newPost, username: 'You', upvotes: 0 }]);
+        setTitle('');
+        setContent('');
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleUpvote = async (id: number) => {
+    try {
+      const res = await fetch(`/api/posts/${id}/upvote`, { method: 'POST' });
+      if (res.ok) {
+        setPosts((prev) =>
+          prev.map((p) => (p.id === id ? { ...p, upvotes: p.upvotes + 1 } : p))
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
     <SiteLayout seoTitle="Community Forum">
@@ -25,15 +69,43 @@ export default function Community() {
         <p className="mb-8 text-gray-700 dark:text-gray-300">
           This is a lightweight space for users to discuss features and share feedback.
         </p>
+        <form onSubmit={handleSubmit} className="space-y-2 mb-8">
+          <input
+            type="text"
+            className="w-full p-2 border rounded"
+            placeholder="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+          <textarea
+            className="w-full p-2 border rounded"
+            placeholder="Share your question or tip"
+            rows={4}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+            Post
+          </button>
+        </form>
+
         <div className="space-y-4">
-          {samplePosts.map((post, idx) => (
-            <div key={idx} className="border rounded p-4">
-              <p className="font-semibold">{post.author}</p>
-              <p>{post.message}</p>
+          {posts.map((post) => (
+            <div key={post.id} className="border rounded p-4">
+              <p className="font-semibold">{post.username}</p>
+              <h2 className="font-bold">{post.title}</h2>
+              <p className="mb-2 whitespace-pre-wrap">{post.content}</p>
+              <button
+                onClick={() => handleUpvote(post.id)}
+                className="text-sm text-blue-600"
+              >
+                Upvote ({post.upvotes})
+              </button>
             </div>
           ))}
         </div>
-        <p className="mt-6 text-gray-500">Full forum functionality coming soon.</p>
       </div>
     </SiteLayout>
   );

--- a/client/src/pages/showcase.tsx
+++ b/client/src/pages/showcase.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import SiteLayout from "@/components/layout/site-layout";
+
+interface ShowcaseEntry {
+  id: number;
+  documentId: number;
+  title: string | null;
+  username: string;
+}
+
+export default function Showcase() {
+  const [entries, setEntries] = useState<ShowcaseEntry[]>([]);
+
+  useEffect(() => {
+    document.title = "Showcase - AI LaTeX Generator";
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription) {
+      metaDescription.setAttribute(
+        'content',
+        'Explore top documents created by the community using AI LaTeX Generator.'
+      );
+    }
+    fetch('/api/showcase')
+      .then((res) => res.json())
+      .then((data) => setEntries(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <SiteLayout seoTitle="Showcase">
+      <div className="container mx-auto px-4 py-12 max-w-3xl">
+        <h1 className="text-4xl font-bold mb-6">Showcase</h1>
+        <p className="mb-8 text-gray-700 dark:text-gray-300">
+          The best user-generated documents shared by our community.
+        </p>
+        <div className="space-y-4">
+          {entries.map((entry) => (
+            <div key={entry.id} className="border rounded p-4">
+              <h2 className="font-semibold">{entry.title || 'Untitled'}</h2>
+              <p className="text-sm mb-2">by {entry.username}</p>
+              <a
+                href={`/?documentId=${entry.documentId}`}
+                className="text-blue-600"
+              >
+                View Document
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/db/migrations/add_posts_and_showcase.sql
+++ b/db/migrations/add_posts_and_showcase.sql
@@ -1,0 +1,27 @@
+-- Community posts table
+CREATE TABLE IF NOT EXISTS posts (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Upvotes for posts
+CREATE TABLE IF NOT EXISTS post_upvotes (
+  id SERIAL PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id),
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT post_upvotes_unique UNIQUE(post_id, user_id)
+);
+
+-- Showcase gallery entries
+CREATE TABLE IF NOT EXISTS showcase_entries (
+  id SERIAL PRIMARY KEY,
+  document_id INTEGER NOT NULL REFERENCES documents(id),
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  title TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add database tables for forum posts and showcase entries
- store posts, upvotes, and showcase in storage layer
- expose `/api/posts` and `/api/showcase` endpoints
- create basic community forum with posting and upvoting
- add showcase gallery page and link in footer

## Testing
- `npm run check` *(fails: Cannot find module 'wouter')*
- `npm test` *(fails: test-pro-plan-checkout.js missing dotenv)*
