### PR TITLE
Add mobile disclaimer env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ DOMAIN=https://your-domain.com
 # Client-side Environment Variables (must start with VITE_)
 VITE_API_BASE_URL=/api
 VITE_STRIPE_PUBLIC_KEY=your_stripe_public_key_here
+VITE_SHOW_MOBILE_DISCLAIMER=false
 
 # Guest mode toggle
 # Set to false by default. Enable only during testing to allow anonymous access.

--- a/client/src/components/dialogs/mobile-disclaimer.tsx
+++ b/client/src/components/dialogs/mobile-disclaimer.tsx
@@ -9,9 +9,9 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
-// Flag to enable/disable the mobile disclaimer
-// Set to true to activate the feature
-const SHOW_MOBILE_DISCLAIMER = false;
+// Flag to enable/disable the mobile disclaimer controlled via environment variable
+// Set VITE_SHOW_MOBILE_DISCLAIMER=true in your .env file to activate the feature
+const SHOW_MOBILE_DISCLAIMER = import.meta.env.VITE_SHOW_MOBILE_DISCLAIMER === 'true';
 
 export default function MobileDisclaimer() {
   const [open, setOpen] = useState(false);

--- a/client/src/components/layout/site-layout.tsx
+++ b/client/src/components/layout/site-layout.tsx
@@ -27,7 +27,7 @@ export default function SiteLayout({
       </main>
       {!hideFooter && <Footer />}
       
-      {/* Mobile disclaimer popup - currently disabled but can be enabled by setting SHOW_MOBILE_DISCLAIMER to true */}
+      {/* Mobile disclaimer popup - enable by setting VITE_SHOW_MOBILE_DISCLAIMER=true */}
       <MobileDisclaimer />
     </div>
   );


### PR DESCRIPTION
## Summary
- allow enabling the mobile disclaimer with `VITE_SHOW_MOBILE_DISCLAIMER`
- read the flag from `import.meta.env`
- update comments describing how to toggle the disclaimer

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*