### PR TITLE
Load latex templates at startup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { updateSystemPromptsWithTemplates } from "./utils/templateLoader";
 
 // Create __dirname equivalent for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -66,6 +67,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  await updateSystemPromptsWithTemplates();
   const server = await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/utils/prompts.ts
+++ b/server/utils/prompts.ts
@@ -1,7 +1,10 @@
 /**
  * System prompt for LaTeX generation
  */
-export const LATEX_SYSTEM_PROMPT = `
+// This string holds the system prompt used by the AI models. It is updated at
+// runtime by updateSystemPromptsWithTemplates() to include any custom templates
+// discovered on disk.
+export let LATEX_SYSTEM_PROMPT = `
 ## Role and Objective
 You are a specialized LaTeX conversion assistant. Your task is to transform plain text input into correctly formatted, compilable LaTeX documents. Analyze the content structure, mathematical expressions, tables, and other elements to produce professional LaTeX code.
 


### PR DESCRIPTION
## Summary
- load templates from `public/templates` and merge into system prompt on startup
- ensure `LATEX_SYSTEM_PROMPT` can be updated at runtime
- load templates before routes are registered

## Testing
- `npm run check` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package 'dotenv')*