### PR TITLE
Add Running Tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ configuration:
 
 Refer to `.env.example` for default values and additional optional variables.
 
+## Running Tests
+
+To run the test suite locally, execute:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner to execute all tests defined in the project.
+
 ## License
 
 Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document how to run the project's tests

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*