### PR TITLE
Use environment variable for domain in robots generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ STRIPE_PRICE_REFILL_PACK_ID=price_refill_pack_id_here
 
 # Domain Configuration (for Production)
 DOMAIN=https://your-domain.com
+SITE_DOMAIN=https://your-domain.com
 
 # Client-side Environment Variables (must start with VITE_)
 VITE_API_BASE_URL=/api

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ deployment platform. Refer to `.env.example` for sample values.
   subscription tiers.
 - `STRIPE_PRICE_REFILL_PACK_ID` - Price ID for refill packs.
 - `DOMAIN` - Production domain used in email links.
+- `SITE_DOMAIN` - Primary site domain used in robots.txt and metadata.
 - `VITE_API_BASE_URL` - Base URL for the frontend API.
 
 Guest mode should only be enabled when testing. For production deployments make

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "db:push": "drizzle-kit push --force --config=./drizzle.config.ts",
     "db:generate": "drizzle-kit generate --config=./drizzle.config.ts",
     "db:migrate": "tsx db/migrate.ts",
-    "test": "node --test"
+    "test": "node --test",
+    "generate:robots": "node scripts/generate-robots.js",
+    "prebuild": "npm run generate:robots"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",

--- a/scripts/generate-robots.js
+++ b/scripts/generate-robots.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const siteDomain = process.env.SITE_DOMAIN || 'https://aitexgen.com';
+
+const robots = `User-agent: *
+Allow: /
+
+# Don't index administrative or authentication pages
+Disallow: /api/
+Disallow: /verify-email
+Disallow: /success
+
+# Sitemap location
+Sitemap: ${siteDomain}/sitemap.xml\n`;
+
+await fs.promises.writeFile(path.resolve(__dirname, '../public/robots.txt'), robots);
+console.log('robots.txt generated for', siteDomain);

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,7 +12,9 @@ const app = express();
 
 // Redirect ads.txt to Ezoic's ads.txt manager before serving static files
 app.get('/ads.txt', (req, res) => {
-  return res.redirect(301, 'https://srv.adstxtmanager.com/74831/aitexgen.com');
+  const domain = (process.env.SITE_DOMAIN || 'https://aitexgen.com')
+    .replace(/^https?:\/\//, '');
+  return res.redirect(301, `https://srv.adstxtmanager.com/74831/${domain}`);
 });
 
 // Serve static files from the public directory

--- a/server/services/aiProvider.ts
+++ b/server/services/aiProvider.ts
@@ -230,7 +230,10 @@ const providers = {
           headers: {
             'Authorization': `Bearer ${openrouterApiKey}`,
             'Content-Type': 'application/json',
-            'HTTP-Referer': process.env.DOMAIN || 'http://localhost:5000',
+            'HTTP-Referer':
+              process.env.SITE_DOMAIN ||
+              process.env.DOMAIN ||
+              'http://localhost:5000',
             'X-Title': 'AI LaTeX Generator'
           }
         }

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -63,7 +63,11 @@ export async function sendVerificationEmail(
     // Determine the base URL based on the environment
     // For Railway, use the PRIMARY_DOMAIN environment variable
     // This will ensure the verification link works in both local and production environments
-    const baseUrl = process.env.PRIMARY_DOMAIN || process.env.PUBLIC_URL || 'http://aitexgen.com';
+    const baseUrl =
+      process.env.PRIMARY_DOMAIN ||
+      process.env.PUBLIC_URL ||
+      process.env.SITE_DOMAIN ||
+      'https://aitexgen.com';
     const verificationLink = `${baseUrl}/verify-email?token=${verificationToken}`;
     
     const response = await client.sendEmail({
@@ -73,7 +77,7 @@ export async function sendVerificationEmail(
       HtmlBody: `
         <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif; border: 1px solid #e5e7eb; border-radius: 8px;">
           <div style="text-align: center; margin-bottom: 24px;">
-            <img src="https://aitexgen.com/logo.png" alt="AITexGen Logo" style="max-width: 120px; height: auto;" onerror="this.style.display='none'">
+            <img src="${baseUrl.replace(/\/$/, '')}/logo.png" alt="AITexGen Logo" style="max-width: 120px; height: auto;" onerror="this.style.display='none'">
           </div>
           <h1 style="color: #2563eb; margin-bottom: 24px; text-align: center;">Verify your email address</h1>
           <p style="margin-bottom: 24px; font-size: 16px; line-height: 24px;">


### PR DESCRIPTION
## Summary
- add `SITE_DOMAIN` variable
- inject domain into robots.txt during build
- reference domain variable in server emails and AI provider
- use domain variable when redirecting ads.txt

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*