### PR TITLE
Add webhook compilation API

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -1,0 +1,17 @@
+name: Compile LaTeX
+on:
+  push:
+    paths:
+      - '**/*.tex'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger compilation
+        run: |
+          curl -X POST https://api.example.com/api/latex/compile/webhook \
+            -H 'Content-Type: application/json' \
+            -d '{"latex":"\\documentclass{article}\\n\\begin{document}Hello CI!\\end{document}","webhookUrl":"${{ secrets.LATEX_WEBHOOK }}"}'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ A comprehensive web-based AI LaTeX Generator that simplifies document creation t
    `STRIPE_WEBHOOK_SECRET`) and the `POSTMARK_API_KEY` used for email.
 4. Run the application: `npm run dev`
 
+## API Integration
+
+The server exposes a `/api/latex/compile/webhook` endpoint so external tools can
+request LaTeX compilation and receive the result via webhook. Send a POST request
+with the LaTeX content and a `webhookUrl` where the compiled PDF should be
+delivered.
+
+```bash
+curl -X POST https://your-server.com/api/latex/compile/webhook \
+  -H 'Content-Type: application/json' \
+  -d '{"latex":"\\documentclass{article}\\n\\begin{document}Hello!\\end{document}","webhookUrl":"https://example.com/hook"}'
+```
+
+Once compilation finishes the server POSTs a JSON payload to the provided URL:
+
+```json
+{ "success": true, "pdf": "base64string" }
+```
+
+### CI/CD Example
+
+The repository includes a sample GitHub Actions workflow in
+`.github/workflows/compile-latex.yml` demonstrating how to invoke the API from a
+pipeline.
+
 ## Documentation
 
 The project includes a growing set of guides under `content/blog` as well as two

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,12 +26,13 @@ const validateRequest = (schema: z.ZodType<any, any>) => {
     }
   };
 };
-import { generateLatexSchema, SubscriptionTier, REFILL_PACK_CREDITS, REFILL_PACK_PRICE, contactSchema } from "@shared/schema";
+import { generateLatexSchema, SubscriptionTier, REFILL_PACK_CREDITS, REFILL_PACK_PRICE, contactSchema, compileWebhookSchema } from "@shared/schema";
 import { generateLatex, getAvailableModels, callProviderWithModel, modifyLatex, rewriteText, generateSummary, generateOutline, generateGlossary, generateFlashcards } from "./services/aiProvider";
 import { compileLatex, compileAndFixLatex } from "./services/latexService";
 import { stripeService } from "./services/stripeService";
 import { stripeSync } from "./services/stripeSync";
 import { testPostmarkConnection, generateVerificationToken, sendVerificationEmail, sendContactEmail } from "./utils/email";
+import { sendWebhook } from "./utils/webhook";
 import Stripe from "stripe";
 import session from "express-session";
 import pgSession from "connect-pg-simple";
@@ -550,6 +551,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
         console.error("LaTeX compilation error:", error);
         return res.status(500).json({ message: "Failed to compile LaTeX" });
       }
+    }
+  );
+
+  app.post('/api/latex/compile/webhook',
+    authenticateUser,
+    validateRequest(compileWebhookSchema),
+    async (req: Request, res: Response) => {
+      const { latex, webhookUrl } = req.body as { latex: string; webhookUrl: string };
+
+      // Run compilation asynchronously and notify via webhook
+      compileLatex(latex).then((result) => {
+        sendWebhook(webhookUrl, result);
+      }).catch((err) => {
+        console.error('Async compilation error:', err);
+        sendWebhook(webhookUrl, { success: false, error: 'Internal error during compilation' });
+      });
+
+      res.status(202).json({ message: 'Compilation started, webhook will receive result' });
     }
   );
 

--- a/server/utils/webhook.ts
+++ b/server/utils/webhook.ts
@@ -1,0 +1,14 @@
+export async function sendWebhook(url: string, payload: unknown): Promise<void> {
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      console.error(`Webhook POST to ${url} failed with status ${res.status}`);
+    }
+  } catch (err) {
+    console.error(`Error sending webhook to ${url}:`, err);
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -172,3 +172,11 @@ export const contactSchema = z.object({
 });
 
 export type ContactForm = z.infer<typeof contactSchema>;
+
+// Schema for webhook-based compilation
+export const compileWebhookSchema = z.object({
+  latex: z.string().min(1, 'LaTeX content is required'),
+  webhookUrl: z.string().url('Valid webhook URL is required')
+});
+
+export type CompileWebhookRequest = z.infer<typeof compileWebhookSchema>;


### PR DESCRIPTION
## Summary
- support webhook-based compilation via `/api/latex/compile/webhook`
- document how to use the API and provide CI example
- include sample GitHub Actions workflow

## Testing
- `npm run check` *(fails: cannot find type declarations)*
- `npm test` *(fails: test-pro-plan-checkout.js)*