### PR TITLE
Add dotenv dependency

### DIFF
--- a/dotenv/index.js
+++ b/dotenv/index.js
@@ -1,1 +1,0 @@
-export function config() { return {}; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "cmdk": "^1.0.0",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.5.0",
         "drizzle-orm": "^0.38.4",
         "drizzle-seed": "^0.3.1",
         "drizzle-zod": "^0.6.0",
@@ -7681,7 +7682,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "db:push": "drizzle-kit push --force --config=./drizzle.config.ts",
     "db:generate": "drizzle-kit generate --config=./drizzle.config.ts",
     "db:migrate": "tsx db/migrate.ts",
-    "test": "node --test",
+    "test": "NODE_PATH=. node --test",
     "generate:robots": "node scripts/generate-robots.js",
     "prebuild": "npm run generate:robots"
   },
@@ -110,7 +110,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",


### PR DESCRIPTION
## Summary
- add dotenv to dependencies in package.json
- remove local stubbed dotenv module
- update `test` script to include `NODE_PATH=.`
- update package-lock.json via `npm install --package-lock-only`

## Testing
- `npm test` *(fails: Error: Cannot find package '/workspace/AILatexGenerator/node_modules/dotenv/index.js' imported from /workspace/AILatexGenerator/test-pro-plan-checkout.js)*