### PR TITLE
Add dynamic SEO meta tags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ TEST_PRO_PLAN_PRICE_ID=test_pro_plan_price_id_here
 # Domain Configuration (for Production)
 DOMAIN=https://your-domain.com
 SITE_DOMAIN=https://your-domain.com
+SITE_TITLE=AI LaTeX Generator
+SITE_DESCRIPTION=Generate professional LaTeX documents with AI assistance.
+SITE_IMAGE=https://your-domain.com/logo.png
 
 # Client-side Environment Variables (must start with VITE_)
 VITE_API_BASE_URL=/api

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ deployment platform. Refer to `.env.example` for sample values.
 - `STRIPE_PRICE_REFILL_PACK_ID` - Price ID for refill packs.
 - `DOMAIN` - Production domain used in email links.
 - `SITE_DOMAIN` - Primary site domain used in robots.txt and metadata.
+- `SITE_TITLE` - Default site title used in templates.
+- `SITE_DESCRIPTION` - Default meta description for pages.
+- `SITE_IMAGE` - Default preview image for social cards.
 - `VITE_API_BASE_URL` - Base URL for the frontend API.
 
 Guest mode should only be enabled when testing. For production deployments make

--- a/server/pug-routes.ts
+++ b/server/pug-routes.ts
@@ -8,9 +8,20 @@ export function setupPugRoutes(app: express.Express) {
 
   // Define template render function to keep DRY
   const renderPugApp = (req: express.Request, res: express.Response) => {
+    const siteTitle = process.env.SITE_TITLE || 'AI LaTeX Generator';
+    const siteDescription =
+      process.env.SITE_DESCRIPTION ||
+      'Generate professional LaTeX documents with AI assistance.';
+    const siteDomain = process.env.SITE_DOMAIN || 'https://aitexgen.com';
+    const siteImage =
+      process.env.SITE_IMAGE || `${siteDomain}/logo.png`;
+
     res.render('app_pug', {
-      title: 'AI LaTeX Generator - Pug Version',
-      userCredits: 3
+      title: siteTitle,
+      description: siteDescription,
+      ogUrl: siteDomain,
+      ogImage: siteImage,
+      userCredits: 3,
     });
   };
 

--- a/views/app_pug.pug
+++ b/views/app_pug.pug
@@ -3,7 +3,18 @@ html(lang="en")
   head
     meta(charset="UTF-8")
     meta(name="viewport", content="width=device-width, initial-scale=1.0")
-    title AI LaTeX Generator - Pug Version
+    meta(name="description", content=description)
+    meta(property="og:type", content="website")
+    meta(property="og:url", content=ogUrl)
+    meta(property="og:title", content=title)
+    meta(property="og:description", content=description)
+    meta(property="og:image", content=ogImage)
+    meta(name="twitter:card", content="summary_large_image")
+    meta(name="twitter:url", content=ogUrl)
+    meta(name="twitter:title", content=title)
+    meta(name="twitter:description", content=description)
+    meta(name="twitter:image", content=ogImage)
+    title= title
     style.
       :root {
         --background: #f8fafc;


### PR DESCRIPTION
## Summary
- enable configurable site title, description, and preview image in `.env`
- inject new values in the Pug route handler
- embed description, Open Graph and Twitter meta tags in `app_pug.pug`
- document new environment variables

## Testing
- `node --import ./dotenv/index.js --test` *(fails: Cannot find package 'dotenv')*