### PR TITLE
Add JWT secret config docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DATABASE_URL=postgresql://postgres:password@localhost:5432/latex_generator
 
 # Authentication
 SESSION_SECRET=your_session_secret_here
+JWT_SECRET=your_jwt_secret_here # Secret for signing JWTs
 
 DEBUG_SESSIONS=false
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ deployment platform. Refer to `.env.example` for sample values.
 - `NODE_ENV` - Environment mode (`development` or `production`).
 - `DATABASE_URL` - PostgreSQL connection string.
 - `SESSION_SECRET` - Secret used to sign sessions.
+- `JWT_SECRET` - Secret key for signing JSON Web Tokens.
 - Session cookies use the `secure` flag when `NODE_ENV` is `production`, so HTTPS is required in that mode.
 - `OPENAI_API_KEY` - OpenAI API key.
 - `ANTHROPIC_API_KEY` - Anthropic API key.

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.23.8",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "dotenv": "^16.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",


### PR DESCRIPTION
## Summary
- document `JWT_SECRET` env var in README
- provide example JWT secret in `.env.example`
- add missing `dotenv` dependency for test script

## Testing
- `NODE_PATH=. npm test`