### PR TITLE
Add Replit hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ A comprehensive web-based AI LaTeX Generator that simplifies document creation t
    - Add a one-time job with the command: `npm run db:push`
    - This will set up your database schema
 
+## Replit Hosting
+
+If you prefer the Replit ecosystem, this repository includes a `.replit` file for effortless setup. See [docs/replit-guide.md](docs/replit-guide.md) for detailed steps.
+
+1. Fork or import the project into Replit.
+2. Define the environment variables shown in `.env.example` using Replit's Secrets panel.
+3. Click **Run** to start `npm run dev`.
+4. The app will be available on Replit's provided webview URL.
+
 ## Local Development
 
 1. Clone this repository

--- a/docs/replit-guide.md
+++ b/docs/replit-guide.md
@@ -1,0 +1,17 @@
+# Replit Hosting Guide
+
+This short guide covers running the AI LaTeX Generator on [Replit](https://replit.com/). The repository already contains a `.replit` configuration that sets up Node.js, Postgres and necessary tools via Nix.
+
+## Steps
+
+1. **Fork or Import** – Create a new Repl based on this repository. Replit will detect the `.replit` file and automatically configure the environment.
+2. **Add Environment Variables** – Open the "Secrets" tab and define the variables listed in [`.env.example`](../.env.example). At a minimum you will need:
+   - `DATABASE_URL`
+   - `SESSION_SECRET`
+   - `JWT_SECRET`
+   - API keys for AI providers (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`)
+   - Stripe keys (`VITE_STRIPE_PUBLIC_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`)
+3. **Run the Project** – Click the **Run** button. Replit executes `npm run dev`, which starts the Express server and Vite in development mode. The webview will show the app on port 5000.
+4. **Persistent Storage** – The included Postgres module starts an ephemeral database. For production use, connect to an external Postgres service and update `DATABASE_URL` accordingly.
+
+With these settings you can prototype the application entirely within Replit's free tier.


### PR DESCRIPTION
## Summary
- document how to run the project on Replit
- link new documentation from the README

## Testing
- `npm test`