### PR TITLE
Fix intro page scroll position

### DIFF
--- a/client/src/pages/intro-page.tsx
+++ b/client/src/pages/intro-page.tsx
@@ -21,6 +21,10 @@ const IntroPage: React.FC = () => {
   // Ensure we start at the top of the page when the component loads
   useEffect(() => {
     window.scrollTo(0, 0);
+    const container = document.querySelector('.intro-page-container');
+    if (container) {
+      (container as HTMLElement).scrollTop = 0;
+    }
   }, []);
 
   // Show skip button and toggle button after a short delay


### PR DESCRIPTION
## Summary
- ensure intro page container resets scrollTop to show content from the top

## Testing
- `node --test`
