### PR TITLE
Add sitemap generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A comprehensive web-based AI LaTeX Generator that simplifies document creation t
 
 5. **Deploy**
    - Railway will automatically deploy your application
+   - During the build phase the `prebuild` script runs `npm run generate:robots && npm run generate:sitemap` to update SEO files
    - After deployment, click on "Generate Domain" to get a public URL
 
 6. **Run Database Migrations**
@@ -141,6 +142,17 @@ deployment platform. Refer to `.env.example` for sample values.
 
 Guest mode should only be enabled when testing. For production deployments make
 sure `GUEST_MODE=false`.
+
+## SEO
+
+Robots and sitemap files are generated automatically. Use the following commands to update them manually:
+
+```bash
+npm run generate:robots
+npm run generate:sitemap
+```
+
+Both commands rely on the `SITE_DOMAIN` environment variable and output files under `public/`. They also run automatically via the `prebuild` script before each build.
 
 ## Stripe Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "db:generate": "drizzle-kit generate --config=./drizzle.config.ts",
     "db:migrate": "tsx db/migrate.ts",
     "test": "node --test",
-    "lint": "eslint \"{client,server}/**/*.{ts,tsx}\""
+    "lint": "eslint \"{client,server}/**/*.{ts,tsx}\"",
+    "generate:robots": "node scripts/generate-robots.js",
+    "generate:sitemap": "node scripts/generate-sitemap.js",
+    "prebuild": "npm run generate:robots && npm run generate:sitemap"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.37.0",

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const siteDomain = process.env.SITE_DOMAIN || 'https://aitexgen.com';
+
+const routes = [
+  { path: '/', changefreq: 'weekly', priority: 1.0 },
+  { path: '/auth', changefreq: 'monthly', priority: 0.8 },
+  { path: '/document-history', changefreq: 'daily', priority: 0.7 },
+  { path: '/account', changefreq: 'monthly', priority: 0.7 },
+  { path: '/subscribe', changefreq: 'monthly', priority: 0.8 },
+  { path: '/refill', changefreq: 'monthly', priority: 0.7 },
+  { path: '/template/article', changefreq: 'monthly', priority: 0.8 },
+  { path: '/template/presentation', changefreq: 'monthly', priority: 0.8 },
+  { path: '/template/letter', changefreq: 'monthly', priority: 0.7 },
+  { path: '/template/report', changefreq: 'monthly', priority: 0.7 }
+];
+
+const lastmod = new Date().toISOString().split('T')[0];
+
+const entries = routes
+  .map(
+    (route) => `  <url>\n    <loc>${siteDomain}${route.path}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>${route.changefreq}</changefreq>\n    <priority>${route.priority}</priority>\n  </url>`
+  )
+  .join('\n');
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+
+await fs.promises.writeFile(
+  path.resolve(__dirname, '../public/sitemap.xml'),
+  sitemap
+);
+
+console.log('sitemap.xml generated for', siteDomain);


### PR DESCRIPTION
## Summary
- add `scripts/generate-sitemap.js` for dynamic sitemap generation
- register `generate:sitemap` and `generate:robots` scripts in package.json
- run both via the new `prebuild` step
- document the SEO commands and mention the prebuild script in deployment instructions

## Testing
- `npm test`