### PR TITLE
Update dev banner injection

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -703,10 +703,16 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script
-      type="text/javascript"
-      src="https://replit.com/public/js/replit-dev-banner.js"
-    ></script>
+    <!-- Load Replit dev banner on *.repl.co or when REPL_ID is set -->
+    <script type="module">
+      if (
+        window.location.hostname.endsWith('.repl.co') ||
+        import.meta.env.REPL_ID
+      ) {
+        const banner = document.createElement('script');
+        banner.src = 'https://replit.com/public/js/replit-dev-banner.js';
+        document.head.appendChild(banner);
+      }
+    </script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
         ]
       : []),
   ],
+  // Expose REPL_* variables to the client along with VITE_ defaults
+  envPrefix: ["VITE_", "REPL_"],
 
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- only load `replit-dev-banner.js` on `*.repl.co` or when `REPL_ID` exists
- expose `REPL_*` env vars to the client via `envPrefix`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run check` *(fails: TS errors)*