### PR TITLE
Add canonical link to Pug template

### DIFF
--- a/server/pug-routes.ts
+++ b/server/pug-routes.ts
@@ -16,10 +16,13 @@ export function setupPugRoutes(app: express.Express) {
     const siteImage =
       process.env.SITE_IMAGE || `${siteDomain}/logo.png`;
 
+    // Compute canonical URL based on the request path
+    const canonicalUrl = `${siteDomain.replace(/\/$/, '')}${req.path}`;
+
     res.render('app_pug', {
       title: siteTitle,
       description: siteDescription,
-      ogUrl: siteDomain,
+      ogUrl: canonicalUrl,
       ogImage: siteImage,
       userCredits: 3,
     });

--- a/views/app_pug.pug
+++ b/views/app_pug.pug
@@ -14,6 +14,7 @@ html(lang="en")
     meta(name="twitter:title", content=title)
     meta(name="twitter:description", content=description)
     meta(name="twitter:image", content=ogImage)
+    link(rel="canonical", href=ogUrl)
     title= title
     style.
       :root {


### PR DESCRIPTION
## Summary
- add `<link rel="canonical" href=ogUrl>` in the Pug template
- compute canonical URL from `SITE_DOMAIN` and the request path in pug routes

## Testing
- `npm test`
