### PR TITLE
Fix mobile overlay blocking Get Started

### DIFF
--- a/client/src/components/background/DistortionBackground.css
+++ b/client/src/components/background/DistortionBackground.css
@@ -20,6 +20,7 @@
   background: transparent;
   opacity: 0;
   z-index: 11;
+  pointer-events: none;
 }
 
 /* Particles backdrop */
@@ -31,6 +32,7 @@
   height: 100%;
   opacity: 0.8;
   z-index: 12;
+  pointer-events: none; /* Allow interactions with elements behind */
 }
 
 /* Particles.js container styles */
@@ -42,6 +44,7 @@
   width: 100%;
   height: 100%;
   z-index: 12;
+  pointer-events: none; /* Ensure background effects don't block clicks */
 }
 
 /* Particles canvas adjustments */
@@ -53,6 +56,7 @@
   width: 100% !important;
   height: 100% !important;
   z-index: 12;
+  pointer-events: none;
 }
 
 /* Scanlines effect */
@@ -254,6 +258,7 @@
 .intro-page-container.distortion-only .gradient-backdrop {
   opacity: 0.95;
   background: radial-gradient(ellipse at center, rgba(59, 130, 246, 0.6) 0%, rgba(79, 70, 229, 0.7) 50%, rgb(56, 99, 168, 0.8) 100%);
+  pointer-events: none;
 }
 
 /* Controls panel */


### PR DESCRIPTION
## Summary
- allow clicks through background overlays so the 'Get Started' button works on mobile

## Testing
- `npm test` *(fails: test-pro-plan-checkout.js)*