### PR TITLE
Add analytics tracking and CTA animations

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,7 @@
     <meta name="monetag" content="cd4002191ba39807c1a9ef684bb4bc01" />
 
     <script
-      async
+      async defer
       src="https://www.googletagmanager.com/gtag/js?id=G-L7X9LGN9PC"
     ></script>
 

--- a/client/src/components/hero/PromptAnimator.css
+++ b/client/src/components/hero/PromptAnimator.css
@@ -471,6 +471,14 @@
   padding: 0;
   position: relative;
   z-index: 100; /* Ensure it's above other elements */
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+.cta-button-container.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .cta-button {

--- a/client/src/components/hero/PromptAnimator.tsx
+++ b/client/src/components/hero/PromptAnimator.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "./PromptAnimator.css";
 import HeroTitle from "./HeroTitle";
+import { trackEvent } from "@/lib/analytics";
 
 interface Props {
   onGetStarted: () => void;
@@ -14,6 +15,7 @@ export default function PromptAnimator({ onGetStarted }: Props) {
     // Prevent default behavior, stop propagation, and call the parent's handler
     e.preventDefault();
     e.stopPropagation();
+    trackEvent('cta_click');
     onGetStarted();
   };
   
@@ -36,6 +38,24 @@ export default function PromptAnimator({ onGetStarted }: Props) {
     return () => {
       window.removeEventListener('resize', handleResize);
     };
+  }, []);
+
+  // Observe CTA visibility for analytics and animation
+  useEffect(() => {
+    const el = document.querySelector('.cta-button-container');
+    if (!el) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          el.classList.add('visible');
+          trackEvent('cta_visible');
+        }
+      });
+    }, { threshold: 0.5 });
+
+    observer.observe(el);
+    return () => observer.disconnect();
   }, []);
   
   const handleDownload = () => {

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -1,0 +1,5 @@
+export function trackEvent(action: string, params: Record<string, any> = {}): void {
+  if (typeof window !== 'undefined' && (window as any).gtag) {
+    (window as any).gtag('event', action, params);
+  }
+}

--- a/client/src/lib/scrollTracker.ts
+++ b/client/src/lib/scrollTracker.ts
@@ -1,0 +1,23 @@
+import { trackEvent } from './analytics';
+
+export function initScrollDepthTracking() {
+  if (typeof window === 'undefined') return;
+  const depths = [25, 50, 75, 100];
+  const fired: Record<number, boolean> = {};
+
+  function onScroll() {
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const scrolled = (window.scrollY / docHeight) * 100;
+    depths.forEach((d) => {
+      if (!fired[d] && scrolled >= d) {
+        fired[d] = true;
+        trackEvent('scroll_depth', { percent: d });
+      }
+    });
+    if (scrolled >= 100) {
+      window.removeEventListener('scroll', onScroll);
+    }
+  }
+
+  window.addEventListener('scroll', onScroll);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,5 +4,7 @@ import "./index.css";
 import "prismjs";
 import "prismjs/components/prism-latex";
 import "prismjs/themes/prism-tomorrow.css";
+import { initScrollDepthTracking } from "./lib/scrollTracker";
 
+initScrollDepthTracking();
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- add `trackEvent` helper for gtag events
- track scroll depth and CTA interaction
- animate CTA with IntersectionObserver
- lazily load GA script with `defer`

## Testing
- `npm test`