### PR TITLE
Update logo link path and remove /app references

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -65,10 +65,10 @@ export default function Header() {
     <header className="bg-white border-b border-gray-200 shadow-sm">
       <div className="container mx-auto px-4 py-3 flex justify-between items-center">
         <div className="flex items-center">
-          <Link 
-            href="/app" 
-            className="flex items-center" 
-            aria-label="Go to AI LaTeX Generator app" 
+          <Link
+            href="/"
+            className="flex items-center"
+            aria-label="Go to AI LaTeX Generator app"
             title="AI LaTeX Generator - App"
             rel="home"
           >

--- a/client/src/pages/intro-page.tsx
+++ b/client/src/pages/intro-page.tsx
@@ -44,7 +44,7 @@ const IntroPage: React.FC = () => {
 
     // Navigate to main app after fade animation completes
     setTimeout(() => {
-      navigate("/app");
+      navigate("/");
     }, 1000);
   };
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -49,7 +49,7 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://aitexgen.com/app</loc>
+    <loc>https://aitexgen.com/</loc>
     <lastmod>2025-05-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -16,7 +16,7 @@ const ignorePages = new Set([
 
 function routeFromFile(name) {
   const base = name.replace(/\.tsx$/, '');
-  if (base === 'home') return '/app';
+  if (base === 'home') return '/';
   if (base === 'index') return '/';
   return `/${base}`;
 }


### PR DESCRIPTION
## Summary
- point header logo to site root
- send intro page to `/` instead of `/app`
- make sitemap route generator return `/`
- fix sitemap URL entry

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*